### PR TITLE
feat: support cross platform virtual environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,9 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Poetry files
+poetry.toml
+
+# VSCode files
+.vscode

--- a/sphinx_diagrams/sphinx_diagrams.py
+++ b/sphinx_diagrams/sphinx_diagrams.py
@@ -116,7 +116,7 @@ def render_diagrams(
 
     ensuredir(path.dirname(output_filename))
 
-    python_args = ["python", "-", Path(fname).stem, "false"]
+    python_args = [sys.executable, "-", Path(fname).stem, "false"]
 
     env = os.environ.copy()
     env["PYTHONPATH"] = f"{os.getcwd()}:{env.get('PYTHONPATH', '')}"

--- a/sphinx_diagrams/sphinx_diagrams.py
+++ b/sphinx_diagrams/sphinx_diagrams.py
@@ -119,7 +119,7 @@ def render_diagrams(
     python_args = [sys.executable, "-", Path(fname).stem, "false"]
 
     env = os.environ.copy()
-    env["PYTHONPATH"] = f"{os.getcwd()}:{env.get('PYTHONPATH', '')}"
+    env["PYTHONPATH"] = os.pathsep.join([os.getcwd(), env.get('PYTHONPATH', '')])
 
     try:
         ret = subprocess.run(


### PR DESCRIPTION
Great extension! I use it every day in my documentation flows.

I use a virtual environment on Windows with Poetry and couldn't get the extension working because Sphinx was using the system Python interpreter instead of the local one where the commands were executed.

Features:
* Support execution inside a virtual environment.
* Support cross-platform path environment variables.

A consideration that it's out of the scope of this pull request:
In my case, the line https://github.com/j-martin/sphinx-diagrams/blob/e6bc2f2130cc3e265df33b83df4ecb8e162a279f/sphinx_diagrams/sphinx_diagrams.py#L122 is not necessary. I didn't think of all the cases but I tested removing it and the extension worked fine. I suppose that it's because I have the module installed in the virtual environment and the extension is already in `sys.path` in my case, hence the Python interpreter finds it and it doesn't need to be added to my environment.