### PR TITLE
chore: bump diagrams from 0.17 to 0.20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sphinx-diagrams"
-version = "0.3.0"
+version = "0.3.1"
 description = "Rendering Diagrams in Sphinx"
 authors = ["Jean-Martin Archer <jm@jmartin.ca>"]
 readme = "README.md"
@@ -9,7 +9,7 @@ repository = "https://github.com/j-martin/sphinx-diagrams"
 
 [tool.poetry.dependencies]
 python = "^3.6"
-diagrams = "^0.17.0"
+diagrams = "^0.20.0"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
Hey, I've had to perform the following changes in order to get new and shiny diagrams such as EC2AutoScaling.

Cheers,